### PR TITLE
Improve CSS structure + fallback fonts

### DIFF
--- a/src/components/Speaker.svelte
+++ b/src/components/Speaker.svelte
@@ -7,45 +7,53 @@
 </script>
 
 <style>
+
   .speaker {
     display: grid;
     grid-gap: 32px;
     --small-grid: var(--media-lte-sm) 1fr;
     grid-template-columns: var(--small-grid, 80px auto);
   }
+
   .image img {
     width: 80px;
     height: 80px;
     object-fit: cover;
     clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
   }
+
   .meta {
     display: grid;
     grid-gap: 15px;
     grid-template-columns: auto 1fr;
     margin-bottom: 8px;
   }
+
   .name {
     color: #e4eef0;
     opacity: 0.67;
   }
-  h3 {
-    font-family: "Overpass";
-    margin: 0 auto;
-    line-height: 140%;
-    padding-top: 5px;
-    font-size: 2em;
-  }
+
   h1 {
-    font-family: "Overpass";
+    font-family: "Overpass", Arial, sans-serif;
     margin: 0 auto;
     line-height: 140%;
     padding-top: 5px;
     font-size: 2em;
   }
+
+  h3 {
+    font-family: "Overpass", Arial, sans-serif;
+    margin: 0 auto;
+    line-height: 140%;
+    padding-top: 5px;
+    font-size: 2em;
+  }
+
   a {
     text-decoration: none;
   }
+
   .twitter {
     display: grid;
     grid-gap: 5px;
@@ -53,27 +61,33 @@
     grid-template-columns: auto 1fr;
     color: #005daa;
   }
+
   .twitter a {
     color: #e4eef0;
 
     opacity: 0.67;
     font-size: 14px;
   }
+
   .twitter img {
     width: 15px;
   }
+
   div :global(p) {
     font-size: 18px;
     color: #bedde2;
     line-height: 170%;
   }
+
+  .viewTalk {
+    margin-top: 2em;
+  }
+
   .viewTalk a {
     background: #307f8b;
     padding: 1em;
   }
-  .viewTalk {
-    margin-top: 2em;
-  }
+
 </style>
 
 <div class="speaker">

--- a/src/components/Speaker.svelte
+++ b/src/components/Speaker.svelte
@@ -1,9 +1,11 @@
 <script>
+
   export let link = false;
   export let viewTalk = false;
   export let singleTalk = false;
   export let speaker;
   const { image, title, name, twitter } = speaker;
+
 </script>
 
 <style>

--- a/src/layouts/Layout.svelte
+++ b/src/layouts/Layout.svelte
@@ -3,35 +3,21 @@
 </script>
 
 <svelte:head>
-  <!-- <link
-    rel="preload"
-    href="/fonts/Anton-Regular.woff"
-    as="font"
-    type="font/woff2"
-    crossorigin />
-  <link
-    rel="preload"
-    href="/fonts/Overpass-Regular.woff2"
-    as="font"
-    type="font/woff2"
-    crossorigin />
-  <link
-    rel="preload"
-    href="/fonts/Overpass-Bold.woff2"
-    as="font"
-    type="font/woff2"
-    crossorigin />
-  <link
-    rel="preload"
-    href="/fonts/Inter-Regular.woff"
-    as="font"
-    type="font/woff2"
-    crossorigin /> -->
+
+  <meta name="theme-color" content="#2D626B" />
   <link rel="stylesheet" href="/style.css" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏔️</text></svg>">
 
-  <!-- <link rel="stylesheet" href="/fonts/fonts.css" /> -->
+  <meta
+    property="twitter:image"
+    content="https://sveltesummit.com/images/metatagimg.png" />
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@sveltesociety" />
+
 </svelte:head>
+
 <div class="container">
   {@html templateHtml}
 </div>

--- a/src/routes/home/Home.svelte
+++ b/src/routes/home/Home.svelte
@@ -12,6 +12,7 @@
 
 <svelte:head>
   <title>Svelte Summit 2020</title>
+  <meta name="theme-color" content="#2D626B" />
   <link rel="canonical" href="https://sveltesummit.com/" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Primary Meta Tags -->

--- a/src/routes/home/Home.svelte
+++ b/src/routes/home/Home.svelte
@@ -12,9 +12,8 @@
 
 <svelte:head>
   <title>Svelte Summit 2020</title>
-  <meta name="theme-color" content="#2D626B" />
   <link rel="canonical" href="https://sveltesummit.com/" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
   <!-- Primary Meta Tags -->
   <title>Svelte Summit is a FREE whole-day online event.</title>
   <meta
@@ -49,6 +48,7 @@
   <meta
     property="twitter:image"
     content="https://sveltesummit.com/images/metatagimg.png" />
+
 </svelte:head>
 
 <Hero />

--- a/src/routes/talks/Talks.svelte
+++ b/src/routes/talks/Talks.svelte
@@ -1,18 +1,26 @@
 <script>
+
   import Speaker from "../../components/Speaker.svelte";
   import Footer from "../../components/Sections/Footer.svelte";
+
   export let data; // data is mainly being populated from the /plugins/edlerjs-plugin-markdown/index.js
+
   $: otherTalks = data.speakers.filter((spkr) => spkr.slug !== data.slug); // not the current talk
   $: nextTalk = otherTalks[Math.floor(Math.random() * otherTalks.length)];
   $: seoTitle = `${data.name} - ${data.title}: SvelteSummit.com`;
+
 </script>
 
 <style>
+
   a {
     text-decoration: none;
-    display: grid;
-    place-items: center;
   }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
 
   .container {
     display: grid;
@@ -21,12 +29,33 @@
     place-items: center;
     padding: 3rem;
   }
+
   .content {
     display: flex;
     flex-direction: column;
   }
+
   #speaker {
     margin-right: 2rem;
+  }
+
+
+  .nextTalk {
+    display: flex;
+    background: #307F8B;
+    padding: 1em;
+  }
+
+  @media (min-width: 1000px) {
+
+    .content {
+      flex-direction: row;
+    }
+
+    #speaker {
+      max-width: 400px;
+    }
+
   }
 
   #HomeButton {
@@ -35,49 +64,36 @@
     align-items: center;
     margin-top: 2rem;
     margin-left: 3rem;
-    background: #1c464d;
+    background: #1C464D;
     border-radius: 50%;
     padding: 1rem;
   }
-  .Footer {
-    margin-top: 1rem;
-    display: flex;
-    flex-direction: column;
-  }
-  a:hover {
-    text-decoration: underline;
-  }
-  .nextTalk {
-    display: flex;
-  }
-  .nextTalk {
-    background: #307f8b;
-    padding: 1em;
-  }
-
-  /* #signUp {
-    font-family: "Inter";
-    text-decoration: none;
-    padding: 15px 20px;
-    font-weight: 500;
-    background: #050606;
-    font-size: 20px;
-    color: #bedde2;
-  } */
 
   @media (min-width: 1000px) {
-    .content {
-      flex-direction: row;
-    }
-    #speaker {
-      max-width: 400px;
-    }
 
     #HomeButton {
       position: absolute;
       top: 3rem;
       left: 2rem;
     }
+
+  }
+
+  /* Footer */
+
+  .Footer {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .Footer a {
+    display: grid;
+    place-items: center;
+  }
+
+  @media (min-width: 1000px) {
+
     .Footer {
       margin-top: 1rem;
       display: flex;
@@ -87,6 +103,7 @@
       flex-direction: row;
     }
   }
+
 </style>
 
 <svelte:head>

--- a/src/routes/talks/Talks.svelte
+++ b/src/routes/talks/Talks.svelte
@@ -107,11 +107,13 @@
 </style>
 
 <svelte:head>
+
   <title>{seoTitle}</title>
-  <meta name="theme-color" content="#2D626B" />
+
   <meta property="title" content={seoTitle} />
   <meta property="og:title" content={seoTitle} />
   <meta name="description" content={data.name + "'s talk at Svelte Summit!"} />
+
   <meta
     property="og:description"
     content={data.name + "'s talk at Svelte Summit!"} />
@@ -123,11 +125,7 @@
   <meta
     property="twitter:description"
     content={data.name + "'s talk at Svelte Summit!"} />
-  <meta
-    property="twitter:image"
-    content="https://sveltesummit.com/images/metatagimg.png" />
-  <meta property="twitter:card" content="summary_large_image" />
-  <meta name="twitter:site" content="@sveltesociety" />
+
 </svelte:head>
 <div id="HomeButton">
   <a href="/#speakers"><svg

--- a/src/routes/talks/Talks.svelte
+++ b/src/routes/talks/Talks.svelte
@@ -108,7 +108,7 @@
 
 <svelte:head>
   <title>{seoTitle}</title>
-  <meta name="theme-color" content="#317EFB" />
+  <meta name="theme-color" content="#2D626B" />
   <meta property="title" content={seoTitle} />
   <meta property="og:title" content={seoTitle} />
   <meta name="description" content={data.name + "'s talk at Svelte Summit!"} />


### PR DESCRIPTION
So, I noticed that we are not loading the right font on the detail pages. I already improved this by setting a fallback font, but we should fix how Overpass (the correct font for the heading) is not loaded on the detail pages.

I can't figure it out, it's something with the Google fonts plugin and the URL request being `./`, which I guess then leads to an error on detail page routes.

```

@font-face {
--
  | font-family: 'Overpass';
  | font-style: normal;
  | font-weight: 400;
  | src: local('Overpass Regular'), local('Overpass-Regular'), url('./qFdH35WCmI96Ajtm81GrU9vyww.woff2') format('woff2');
  | unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
  | }

```

Signed-off-by: Wolfr <johan.ronsse@gmail.com>