### PR TITLE
Use the www.gitpod.io URL rather than gitpod.io

### DIFF
--- a/src/components/Sections/Sponsors.svelte
+++ b/src/components/Sections/Sponsors.svelte
@@ -8,7 +8,7 @@
 			image: "filevine.svg",
 		},
 		{
-			url: "https://gitpod.io",
+			url: "https://www.gitpod.io",
 			name: "Gitpod",
 			description:
 				"Remove all friction from the developer experience to be always ready-to-code and make software engineering more collaborative, joyful, and secure.",


### PR DESCRIPTION
For clarification, the www subdomain is where we host the marketing website. The root domain is the Gitpod product itself.